### PR TITLE
add parenthesis to a print statement to maintain python3 compatibility

### DIFF
--- a/spyrk/spark_cloud.py
+++ b/spyrk/spark_cloud.py
@@ -119,7 +119,7 @@ class SparkCloud(object):
                 # ensure the set of all keys is present in the dictionnary (Device constructor requires all keys present)
                 [d.setdefault(key, None) for key in allKeys]
 
-                print d
+                print(d)
                 devices_dict[d['name']] = Device(**d)
                 
         return devices_dict


### PR DESCRIPTION
This print statement breaks python3 compatibility without parenthesis. You may also consider removing it altogether.